### PR TITLE
added EventInteraction model and added get, post, and put requests #21

### DIFF
--- a/services/interactions/src/models/interaction.ts
+++ b/services/interactions/src/models/interaction.ts
@@ -1,7 +1,24 @@
-import { Schema, model } from "mongoose";
+import { Schema, model, Types } from "mongoose";
 
-export interface Interaction {}
+export interface Interaction {
+    uuid: string,
+    userid: string,
+    timeIn: string,
+}
 
-const interactionSchema = new Schema<Interaction>({});
+const interactionSchema = new Schema<Interaction>({
+    uuid: {
+        type: String,
+        required: true,
+    },
+    userid: {
+        type: String,
+        required: true,
+    },
+    timeIn: {
+        type: String,
+        required: true,
+    }
+});
 
-export const InteractionModel = model<Interaction>("Interaction", interactionSchema);
+export const EventInteraction = model<Interaction>("Interaction", interactionSchema);

--- a/services/interactions/src/routes/interaction.ts
+++ b/services/interactions/src/routes/interaction.ts
@@ -1,20 +1,92 @@
 import { asyncHandler } from "@api/common";
+import EventEmitter from "events";
 import express from "express";
+import { EventInteraction } from "src/models/interaction";
 
 export const interactionRoutes = express.Router();
 
-interactionRoutes.route("/").get(asyncHandler(async (req, res) => res.send()));
+interactionRoutes.route("/").get(asyncHandler(async (req, res) => {
+  const interactions = await EventInteraction.find({});
 
-interactionRoutes.route("/").post(asyncHandler(async (req, res) => res.send()));
+  return res.send(interactions);
+}));
 
-interactionRoutes.route("/:id").get(
+const requestParams = ["uuid", "userid"];
+
+interactionRoutes.route("/").post(asyncHandler(async (req, res) => {
+  try {
+    // validate request to make sure types are there
+    for (const param of requestParams) {
+      if (!req.body[param]) {
+        console.log(`no ${param}`);
+        return res.status(400).send(`no ${param}`);
+      }
+    }
+    
+    try {
+      let interaction = await EventInteraction.findOneAndUpdate(
+        {uuid: req.body.uuid, userid: req.body.userid},
+        {
+          $setOnInsert: EventInteraction.create({
+            uuid: req.body.uuid,
+            userid: req.body.userid,
+            timeIn: (new Date()).toLocaleString(),
+          }),
+        },
+        {upsert: true, runValidators: true},
+      );
+
+      if (!interaction) {
+        throw "interaction not found";
+      }
+
+      // Interaction was just created
+      if (interaction.timeIn && interaction.timeIn == (new Date()).toLocaleString()) {
+        return res.status(200).send("success");
+      }
+      if (interaction.timeIn && interaction.timeIn != (new Date()).toLocaleString()) {
+        return res.status(400).send("interaction already exists for user");
+      }
+      throw "interaction timeIn not found";
+    } catch (err) {
+      console.log(`Error when getting/inserting interaction: ${err}`);
+      return res.status(400).send("Error when get/insert interaction");
+    }
+
+  } catch (err) {
+    console.log((err as Error).message);
+    return res.sendStatus(500);
+  }
+}));
+
+interactionRoutes.route("/:uuid").get(
   asyncHandler(async (req, res) => {
     res.send();
   })
 );
 
-interactionRoutes.route("/:id").put(
+interactionRoutes.route("/:uuid/:userid").put(
   asyncHandler(async (req, res) => {
-    res.send();
+    let interaction = await EventInteraction.findOneAndUpdate(
+      {uuid: req.body.uuid, userid: req.body.userid},
+      {
+        $set: {
+          uuid: req.params.uuid,
+          userid: req.params.userid,
+          timeIn: (new Date()).toLocaleString(),
+        },
+      },
+      {runValidators: true},
+    );
+
+    if (!interaction) {
+      return res.status(400).send("interaction does not exist")
+    }
+
+    if (!interaction.uuid || !interaction.userid || !interaction.timeIn) {
+      return res.status(400).send("interaction is missing a parameter");
+    }
+
+    return res.status(200).send("success")
   })
 );


### PR DESCRIPTION
Issue #21  

created a new EventInteraction model and added a get request to retrieve all interactions for a user, a post request to create a new interaction for a user, and a put request to edit an existing interaction for a user. Based a lot of the error handling off of the yac repo, but adapted it to this new model.