### PR TITLE
Changed hexathon to interaction in one instance

### DIFF
--- a/docs/src/swagger-output.json
+++ b/docs/src/swagger-output.json
@@ -457,7 +457,7 @@
     "/interactions/{id}": {
       "put": {
         "tags": ["interactions"],
-        "summary": "Update an existing hexathon by id.",
+        "summary": "Update an existing interaction by id.",
         "description": "",
         "consumes": ["application/json"],
         "produces": ["application/json"],


### PR DESCRIPTION
Noticed a naming error; in one of the interactions route, there was a mention about hexathon instead. FIxed it now.