### PR TITLE
Add start and end date fields for hexathon model and docs site

### DIFF
--- a/docs/src/swagger-output.json
+++ b/docs/src/swagger-output.json
@@ -535,6 +535,14 @@
                 },
                 "isActive": {
                   "type": "boolean"
+                },
+                "startDate": {
+                  "type": "date-time",
+                  "required": true
+                },
+                "endDate": {
+                  "type": "date-time",
+                  "required": true
                 }
               }
             }
@@ -1710,6 +1718,14 @@
         "isActive": {
           "type": "boolean",
           "default": true
+        },
+        "startDate": {
+          "type": "date-time",
+          "required": true
+        },
+        "endDate": {
+          "type": "date-time",
+          "required": true
         }
       },
       "xml": {

--- a/services/hexathons/src/models/hexathon.ts
+++ b/services/hexathons/src/models/hexathon.ts
@@ -3,6 +3,8 @@ import { Schema, model } from "mongoose";
 export interface Hexathon {
   name: string;
   isActive: boolean;
+  startDate: Date;
+  endDate: Date;
 }
 
 const hexathonSchema = new Schema<Hexathon>({
@@ -14,6 +16,14 @@ const hexathonSchema = new Schema<Hexathon>({
     type: Boolean,
     required: true,
     default: true,
+  },
+  startDate: {
+    type: Date,
+    required: true,
+  },
+  endDate: {
+    type: Date,
+    required: true,
   },
 });
 


### PR DESCRIPTION
### Description
- Creates start and end date fields for hexathon model
- Adds newly added fields to API docs site

### Issues
- #64 