### PR TITLE
Create new permissions inside auth service

### DIFF
--- a/common/src/rateLimit.ts
+++ b/common/src/rateLimit.ts
@@ -25,7 +25,6 @@ export const rateLimiter = () => {
       standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
       legacyHeaders: false, // Disable the `X-RateLimit-*` headers
       message: {
-        //
         status: StatusCodes.TOO_MANY_REQUESTS,
         type: "rate_limit_error",
         message: "Too many requests sent. Please try again later.",

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -1,4 +1,41 @@
+import { DecodedIdToken } from "firebase-admin/lib/auth/token-verifier";
 import mongoose from "mongoose";
+
+/**
+ * User roles in the system for managing permissions.
+ */
+export interface UserRoles {
+  member: boolean;
+  exec: boolean;
+  admin: boolean;
+}
+
+/**
+ * Default permission roles for new users.
+ */
+export const DEFAULT_USER_ROLES: UserRoles = {
+  member: false,
+  exec: false,
+  admin: false,
+};
+
+declare global {
+  namespace Express {
+    interface Request {
+      /**
+       * Represents the user that is currently authenticated.
+       */
+      user: (DecodedIdToken & { roles: UserRoles }) | null;
+
+      /**
+       * Used to set an error when decoding the user token. This is used so that when isAuthenticated
+       * is called, the middleware can check if the user is authenticated or not, and if not, throw
+       * an appropriate error.
+       */
+      userError: any;
+    }
+  }
+}
 
 /**
  * Follows the definition from mongoose.PopulatedDoc. Essentially a wrapper around a mongose

--- a/config/src/dev.ts
+++ b/config/src/dev.ts
@@ -154,6 +154,10 @@ export const SERVICES: Record<Service, ServiceConfig> = {
         [`^/auth`]: "",
       },
     },
+    database: {
+      type: "mongo",
+      name: "auth",
+    },
   },
 };
 

--- a/config/src/prod.ts
+++ b/config/src/prod.ts
@@ -142,6 +142,10 @@ export const SERVICES: Record<Service, ServiceConfig> = {
         [`^/auth`]: "",
       },
     },
+    database: {
+      type: "mongo",
+      name: "auth",
+    },
   },
 };
 

--- a/docs/src/swagger-output.json
+++ b/docs/src/swagger-output.json
@@ -1654,7 +1654,8 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/Profile"
+              "type": "object",
+              "allOf": [{ "$ref": "#/definitions/Profile" }, { "$ref": "#/definitions/Permission" }]
             }
           },
           "400": {
@@ -2111,6 +2112,31 @@
       },
       "xml": {
         "name": "Profile"
+      }
+    },
+    "Permission": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string"
+        },
+        "roles": {
+          "type": "object",
+          "properties": {
+            "member": {
+              "type": "boolean"
+            },
+            "exec": {
+              "type": "boolean"
+            },
+            "admin": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "xml": {
+        "name": "Permission"
       }
     },
     "User": {

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -32,6 +32,7 @@
     "firebase-admin": "^10.0.2",
     "fs": "^0.0.1-security",
     "helmet": "^5.0.2",
+    "mongoose": "^6.4.4",
     "morgan": "^1.10.0",
     "path": "^0.12.7",
     "re2": "^1.17.4",

--- a/services/auth/src/app.ts
+++ b/services/auth/src/app.ts
@@ -3,8 +3,9 @@ import compression from "compression";
 import morgan from "morgan";
 import cors from "cors";
 import helmet from "helmet";
-import config from "@api/config";
+import config, { Service } from "@api/config";
 import { decodeToken, handleError, rateLimiter } from "@api/common";
+import mongoose from "mongoose";
 import cookieParser from "cookie-parser";
 
 import { defaultRouter } from "./routes";
@@ -20,10 +21,19 @@ if (config.common.production) {
   app.enable("trust proxy");
 }
 
+mongoose
+  .connect(config.database.mongo.uri, {
+    dbName: config.services.AUTH.database?.name,
+  })
+  .catch(err => {
+    throw err;
+  });
+mongoose.set("runValidators", true);
+
 app.use(helmet());
 app.use(rateLimiter());
 app.use(cookieParser());
-app.use(decodeToken);
+app.use(decodeToken(Service.AUTH));
 app.use(morgan("dev"));
 app.use(compression());
 app.use(

--- a/services/auth/src/models/permission.ts
+++ b/services/auth/src/models/permission.ts
@@ -1,0 +1,31 @@
+import { UserRoles } from "@api/common";
+import { Schema, model } from "mongoose";
+
+export interface Permission {
+  userId: string;
+  roles: UserRoles;
+}
+
+const permissionSchema = new Schema<Permission>({
+  userId: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  roles: {
+    member: {
+      type: Boolean,
+      default: false,
+    },
+    exec: {
+      type: Boolean,
+      default: false,
+    },
+    admin: {
+      type: Boolean,
+      default: false,
+    },
+  },
+});
+
+export const PermissionModel = model<Permission>("Permission", permissionSchema);

--- a/services/auth/src/routes/index.ts
+++ b/services/auth/src/routes/index.ts
@@ -2,8 +2,10 @@ import express from "express";
 
 import { authRoutes } from "./auth";
 import { firebaseUsersRoutes } from "./firebase-users";
+import { permissionRoutes } from "./permission";
 
 export const defaultRouter = express.Router();
 
 defaultRouter.use("/auth", authRoutes);
 defaultRouter.use("/firebase-users", firebaseUsersRoutes);
+defaultRouter.use("/permissions", permissionRoutes);

--- a/services/auth/src/routes/permission.ts
+++ b/services/auth/src/routes/permission.ts
@@ -1,0 +1,75 @@
+import { asyncHandler, DEFAULT_USER_ROLES, ForbiddenError } from "@api/common";
+import express from "express";
+
+import { PermissionModel } from "../models/permission";
+
+/**
+ * Note that for all the routes in this file, the req.user.roles field is set
+ * to the default values. This is to prevent an infinite loop. As such, whenever
+ * you want to access user permissions, you will need to read it from the database.
+ */
+
+export const permissionRoutes = express.Router();
+
+permissionRoutes.route("/:userId").get(
+  asyncHandler(async (req, res) => {
+    // If the user is not checking their own permissions, they must have the member role
+    if (req.params.userId !== req.user?.uid) {
+      const currentUserPermissions = await PermissionModel.findOne({
+        userId: req.user?.uid,
+      });
+      if (!currentUserPermissions?.roles?.member) {
+        throw new ForbiddenError("You do not have permission to access this endpoint.");
+      }
+    }
+
+    const permission = await PermissionModel.findOne(
+      {
+        userId: req.params.userId,
+      },
+      { _id: false }
+    );
+
+    res.send(
+      permission || {
+        userId: req.params.userId,
+        ...DEFAULT_USER_ROLES,
+      }
+    );
+  })
+);
+
+permissionRoutes.route("/").post(
+  asyncHandler(async (req, res) => {
+    const currentUserPermissions = await PermissionModel.findOne({
+      userId: req.user?.uid,
+    });
+    if (!currentUserPermissions?.roles?.admin) {
+      throw new ForbiddenError("You do not have permission to access this endpoint.");
+    }
+
+    const newPermission = await PermissionModel.create(req.body);
+
+    res.send(newPermission);
+  })
+);
+
+permissionRoutes.route("/:userId").patch(
+  asyncHandler(async (req, res) => {
+    const currentUserPermissions = await PermissionModel.findOne({
+      userId: req.user?.uid,
+    });
+    if (!currentUserPermissions?.roles?.admin) {
+      throw new ForbiddenError("You do not have permission to access this endpoint.");
+    }
+
+    const roles = req.body?.roles;
+    const newPermission = await PermissionModel.findOneAndUpdate(
+      { userId: req.params.userId },
+      { roles },
+      { new: true }
+    );
+
+    res.send(newPermission);
+  })
+);

--- a/services/checkin/src/app.ts
+++ b/services/checkin/src/app.ts
@@ -3,7 +3,7 @@ import compression from "compression";
 import morgan from "morgan";
 import cors from "cors";
 import helmet from "helmet";
-import config from "@api/config";
+import config, { Service } from "@api/config";
 import { decodeToken, handleError, isAuthenticated, rateLimiter } from "@api/common";
 import mongoose from "mongoose";
 import cookieParser from "cookie-parser";
@@ -33,7 +33,7 @@ mongoose.set("runValidators", true);
 app.use(helmet());
 app.use(rateLimiter());
 app.use(cookieParser());
-app.use(decodeToken);
+app.use(decodeToken(Service.CHECKIN));
 app.use(morgan("dev"));
 app.use(compression());
 app.use(

--- a/services/files/src/app.ts
+++ b/services/files/src/app.ts
@@ -3,7 +3,7 @@ import compression from "compression";
 import morgan from "morgan";
 import cors from "cors";
 import helmet from "helmet";
-import config from "@api/config";
+import config, { Service } from "@api/config";
 import { decodeToken, handleError, isAuthenticated, rateLimiter } from "@api/common";
 import mongoose from "mongoose";
 import cookieParser from "cookie-parser";
@@ -33,7 +33,7 @@ mongoose.set("runValidators", true);
 app.use(helmet());
 app.use(rateLimiter());
 app.use(cookieParser());
-app.use(decodeToken);
+app.use(decodeToken(Service.FILES));
 app.use(morgan("dev"));
 app.use(compression());
 app.use(

--- a/services/hexathons/src/app.ts
+++ b/services/hexathons/src/app.ts
@@ -3,7 +3,7 @@ import compression from "compression";
 import morgan from "morgan";
 import cors from "cors";
 import helmet from "helmet";
-import config from "@api/config";
+import config, { Service } from "@api/config";
 import { decodeToken, handleError, isAuthenticated, rateLimiter } from "@api/common";
 import mongoose from "mongoose";
 import cookieParser from "cookie-parser";
@@ -33,7 +33,7 @@ mongoose.set("runValidators", true);
 app.use(helmet());
 app.use(rateLimiter());
 app.use(cookieParser());
-app.use(decodeToken);
+app.use(decodeToken(Service.HEXATHONS));
 app.use(morgan("dev"));
 app.use(compression());
 app.use(

--- a/services/interactions/src/app.ts
+++ b/services/interactions/src/app.ts
@@ -3,7 +3,7 @@ import compression from "compression";
 import morgan from "morgan";
 import cors from "cors";
 import helmet from "helmet";
-import config from "@api/config";
+import config, { Service } from "@api/config";
 import { decodeToken, handleError, rateLimiter } from "@api/common";
 import mongoose from "mongoose";
 import cookieParser from "cookie-parser";
@@ -33,7 +33,7 @@ mongoose.set("runValidators", true);
 app.use(helmet());
 app.use(rateLimiter());
 app.use(cookieParser());
-app.use(decodeToken);
+app.use(decodeToken(Service.INTERACTIONS));
 app.use(morgan("dev"));
 app.use(compression());
 app.use(

--- a/services/notifications/src/app.ts
+++ b/services/notifications/src/app.ts
@@ -3,7 +3,7 @@ import compression from "compression";
 import morgan from "morgan";
 import cors from "cors";
 import helmet from "helmet";
-import config from "@api/config";
+import config, { Service } from "@api/config";
 import { decodeToken, handleError, isAuthenticated, rateLimiter } from "@api/common";
 import mongoose from "mongoose";
 import cookieParser from "cookie-parser";
@@ -33,7 +33,7 @@ mongoose.set("runValidators", true);
 app.use(helmet());
 app.use(rateLimiter());
 app.use(cookieParser());
-app.use(decodeToken);
+app.use(decodeToken(Service.NOTIFICATIONS));
 app.use(morgan("dev"));
 app.use(compression());
 app.use(

--- a/services/registration/src/app.ts
+++ b/services/registration/src/app.ts
@@ -3,7 +3,7 @@ import compression from "compression";
 import morgan from "morgan";
 import cors from "cors";
 import helmet from "helmet";
-import config from "@api/config";
+import config, { Service } from "@api/config";
 import { decodeToken, handleError, isAuthenticated, rateLimiter } from "@api/common";
 import mongoose from "mongoose";
 import cookieParser from "cookie-parser";
@@ -33,7 +33,7 @@ mongoose.set("runValidators", true);
 app.use(helmet());
 app.use(rateLimiter());
 app.use(cookieParser());
-app.use(decodeToken);
+app.use(decodeToken(Service.REGISTRATION));
 app.use(morgan("dev"));
 app.use(compression());
 app.use(

--- a/services/users/src/app.ts
+++ b/services/users/src/app.ts
@@ -3,7 +3,7 @@ import compression from "compression";
 import morgan from "morgan";
 import cors from "cors";
 import helmet from "helmet";
-import config from "@api/config";
+import config, { Service } from "@api/config";
 import { decodeToken, handleError, isAuthenticated, rateLimiter } from "@api/common";
 import mongoose from "mongoose";
 import cookieParser from "cookie-parser";
@@ -33,7 +33,7 @@ mongoose.set("runValidators", true);
 app.use(helmet());
 app.use(rateLimiter());
 app.use(cookieParser());
-app.use(decodeToken);
+app.use(decodeToken(Service.USERS));
 app.use(morgan("dev"));
 app.use(compression());
 app.use(

--- a/services/users/src/models/profile.ts
+++ b/services/users/src/models/profile.ts
@@ -6,17 +6,12 @@ export interface Profile {
   email: string;
   name: {
     first: string;
-    middle: string;
+    middle?: string;
     last: string;
   };
-  phoneNumber: string;
-  gender: string;
-  resume: Types.ObjectId;
-  permissions: {
-    member: boolean;
-    exec: boolean;
-    admin: boolean;
-  };
+  phoneNumber?: string;
+  gender?: string;
+  resume?: Types.ObjectId;
 }
 
 const profileSchema = new Schema<Profile>({
@@ -52,20 +47,6 @@ const profileSchema = new Schema<Profile>({
     type: String,
   },
   resume: Types.ObjectId,
-  permissions: {
-    member: {
-      type: Boolean,
-      default: false,
-    },
-    exec: {
-      type: Boolean,
-      default: false,
-    },
-    admin: {
-      type: Boolean,
-      default: false,
-    },
-  },
 });
 
 profileSchema.plugin(mongoosePaginate);

--- a/services/users/src/routes/user.ts
+++ b/services/users/src/routes/user.ts
@@ -1,4 +1,5 @@
-import { asyncHandler, BadRequestError } from "@api/common";
+import { apiCall, asyncHandler } from "@api/common";
+import { Service } from "@api/config";
 import express from "express";
 import { FilterQuery } from "mongoose";
 
@@ -33,16 +34,6 @@ userRoutes.route("/").get(
         { phoneNumber: { $regex: re } },
         { email: { $regex: re } },
       ];
-    }
-
-    if (req.query.member != null) {
-      filter.permissions.member = req.query.member;
-    }
-    if (req.query.admin != null) {
-      filter.permissions.admin = req.query.admin;
-    }
-    if (req.query.exec != null) {
-      filter.permissions.exec = req.query.exec;
     }
 
     const matchCount = await ProfileModel.find(filter).count();
@@ -87,22 +78,23 @@ userRoutes.route("/:userId").get(
       userId: req.params.userId,
     });
 
-    res.send(profile || {});
+    const permission = await apiCall(
+      Service.AUTH,
+      { method: "GET", url: `/permissions/${req.params.userId}` },
+      req
+    );
+
+    const combinedProfile = {
+      ...profile?.toObject(),
+      ...permission,
+    };
+
+    res.send(combinedProfile || {});
   })
 );
 
 userRoutes.route("/:userId").put(
   asyncHandler(async (req, res) => {
-    if (req.body.permissions) {
-      const profile = await ProfileModel.findOne({
-        userId: req.user?.uid,
-      });
-
-      if (!profile || !(profile.permissions.exec || profile.permissions.admin)) {
-        throw new BadRequestError("Unauthorized to modify permissions");
-      }
-    }
-
     const updatedProfile = await ProfileModel.findOneAndUpdate(
       { userId: req.params.userId },
       req.body,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1116,6 +1116,13 @@ bson@^4.6.2:
   dependencies:
     buffer "^5.6.0"
 
+bson@^4.6.3:
+  version "4.6.5"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-4.6.5.tgz#1a410148c20eef4e40d484878a037a7036e840fb"
+  integrity sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==
+  dependencies:
+    buffer "^5.6.0"
+
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
@@ -3230,6 +3237,11 @@ kareem@2.3.5:
   resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.3.5.tgz#111fe9dbab754c8ed88b7a2360e2680cec1420ca"
   integrity sha512-qxCyQtp3ioawkiRNQr/v8xw9KIviMSSNmy+63Wubj7KmMn3g7noRXIZB4vPCAP+ETi2SR8eH6CvmlKZuGpoHOg==
 
+kareem@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.4.1.tgz#7d81ec518204a48c1cb16554af126806c3cd82b0"
+  integrity sha512-aJ9opVoXroQUPfovYP5kaj2lM7Jn02Gw13bL0lg9v0V7SaUc0qavPs0Eue7d2DcC3NjqI6QAUElXNsuZSeM+EA==
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -3721,6 +3733,18 @@ mongodb@4.5.0:
   optionalDependencies:
     saslprep "^1.0.3"
 
+mongodb@4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.7.0.tgz#99f7323271d93659067695b60e7b4efee2de9bf0"
+  integrity sha512-HhVar6hsUeMAVlIbwQwWtV36iyjKd9qdhY+s4wcU8K6TOj4Q331iiMy+FoPuxEntDIijTYWivwFJkLv8q/ZgvA==
+  dependencies:
+    bson "^4.6.3"
+    denque "^2.0.1"
+    mongodb-connection-string-url "^2.5.2"
+    socks "^2.6.2"
+  optionalDependencies:
+    saslprep "^1.0.3"
+
 mongodb@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.4.0.tgz#3b14b9701067713d5c9afb6d6e4a86ca7b969824"
@@ -3781,6 +3805,19 @@ mongoose@^6.3.0:
     ms "2.1.3"
     sift "16.0.0"
 
+mongoose@^6.4.4:
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-6.4.4.tgz#4e22a36373d8a867ee8f73063d8b31f1e451316d"
+  integrity sha512-r6sp96veRNhNIWFtHHe4Lqak+ilgiExYnnMLhYTGdzjIMR90G1ayx0JKFVdHuC6dKNHGFX0ETJGbf36N8Romjg==
+  dependencies:
+    bson "^4.6.2"
+    kareem "2.4.1"
+    mongodb "4.7.0"
+    mpath "0.9.0"
+    mquery "4.0.3"
+    ms "2.1.3"
+    sift "16.0.0"
+
 moo@^0.5.0, moo@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
@@ -3802,10 +3839,22 @@ mpath@0.8.4:
   resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.8.4.tgz#6b566d9581621d9e931dd3b142ed3618e7599313"
   integrity sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g==
 
+mpath@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.9.0.tgz#0c122fe107846e31fc58c75b09c35514b3871904"
+  integrity sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==
+
 mquery@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/mquery/-/mquery-4.0.2.tgz#a13add5ecd7c2e5a67e0f814b3c7acdfb6772804"
   integrity sha512-oAVF0Nil1mT3rxty6Zln4YiD6x6QsUWYz927jZzjMxOK2aqmhEz5JQ7xmrKK7xRFA2dwV+YaOpKU/S+vfNqKxA==
+  dependencies:
+    debug "4.x"
+
+mquery@4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/mquery/-/mquery-4.0.3.tgz#4d15f938e6247d773a942c912d9748bd1965f89d"
+  integrity sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==
   dependencies:
     debug "4.x"
 


### PR DESCRIPTION
### Description

Separated out permissions handling into it's own model inside the auth service. Currently, some of the permissions stuff lived inside the users service and was handled in the profile model, but I wanted to move it here to give it the chance to grow on it's own. Additionally, I added in some checking at the middleware to each request to add user permissions. In a different PR, I'll start adding in permissions checking middleware into each endpoint.
