### PR TITLE
Move grading decisions to a branch

### DIFF
--- a/docs/src/swagger-output.json
+++ b/docs/src/swagger-output.json
@@ -1392,6 +1392,10 @@
               "properties": {
                 "hexathon": {
                   "type": "string"
+                },
+                "gradingGroup": {
+                  "type": "string",
+                  "enum": ["generalGroup", "emergingGroup"]
                 }
               }
             }
@@ -1459,6 +1463,10 @@
                 },
                 "hexathon": {
                   "type": "string"
+                },
+                "gradingGroup": {
+                  "type": "string",
+                  "enum": ["generalGroup", "emergingGroup"]
                 },
                 "score": {
                   "type": "integer"
@@ -2506,6 +2514,18 @@
               }
             }
           }
+        },
+        "grading": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "group": {
+              "type": "string",
+              "enum": ["generalGroup", "emergingGroup"]
+            }
+          }
         }
       },
       "xml": {
@@ -2527,22 +2547,14 @@
         "skipped": {
           "type": "number"
         },
-        "currentGradingGroup": {
-          "type": "string"
-        },
-        "completedGradingGroups": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "calibrationScores": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "group": {
-                "type": "string"
+                "type": "string",
+                "enum": ["generalGroup", "emergingGroup"]
               },
               "score": {
                 "type": "number"

--- a/services/registration/src/common/mapScores.ts
+++ b/services/registration/src/common/mapScores.ts
@@ -1,6 +1,6 @@
 import { ConfigError } from "@api/common";
 
-import { calibrationQuestionMapping, gradingGroupMapping, rubricMapping } from "../config";
+import { calibrationQuestionMapping, rubricMapping } from "../config";
 
 type UserScoresByGroup = {
   [group: string]: {
@@ -114,9 +114,10 @@ function mapCalibrationScores(
     // Computes all the criteria for each of the branches in this group. Since some of the criteria
     // may overlap, a set is used to prevent duplicates.
     const allCriteriasSet = new Set<string>();
-    for (const branch of gradingGroupMapping[group].branches) {
-      Object.keys(rubricMapping[branch]).forEach(criteria => allCriteriasSet.add(criteria));
-    }
+    // TODO: Needs to be updated since we aren't mapping by branch anymore, but by criteria
+    // for (const branch of gradingGroupMapping[group].branches) {
+    //   Object.keys(rubricMapping[branch]).forEach(criteria => allCriteriasSet.add(criteria));
+    // }
     const criterias = Array.from(allCriteriasSet);
 
     for (const criteria of criterias) {

--- a/services/registration/src/common/util.ts
+++ b/services/registration/src/common/util.ts
@@ -1,4 +1,4 @@
-import { BadRequestError, ConfigError } from "@api/common";
+import { BadRequestError } from "@api/common";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
 import express from "express";
@@ -86,37 +86,3 @@ export const getBranch = (
       throw new BadRequestError("Invalid branch type.");
   }
 };
-
-/**
- * Get initial grading group for a user by reading the config .json file. If a user email is specifically assigned to a
- * grading group, then that group is returned. Otherwise, the default grading group is returned. This is the grading group
- * specified with "emails": "rest".
- * @param email the user's email address
- * @param gradingGroupMapping the grading group mapping read from the config file
- * @returns the specified user's grading group
- */
-export function getUserInitialGradingGroup(email: string, gradingGroupMapping: any) {
-  let initialGradingGroup: string | undefined;
-  let restGradingGroup: string | undefined;
-
-  for (const gradingGroup of Object.keys(gradingGroupMapping)) {
-    if (gradingGroupMapping[gradingGroup].emails === "rest") {
-      restGradingGroup = gradingGroup;
-    } else if (
-      Array.isArray(gradingGroupMapping[gradingGroup].emails) &&
-      gradingGroupMapping[gradingGroup].emails.includes(email)
-    ) {
-      initialGradingGroup = gradingGroup;
-    }
-  }
-  // If no specific grading group is found, set the default rest grading group
-  initialGradingGroup = initialGradingGroup ?? restGradingGroup;
-
-  if (!initialGradingGroup) {
-    throw new ConfigError(
-      "User grading group not set. Please ask a tech team member to update the config mapping."
-    );
-  }
-
-  return initialGradingGroup;
-}

--- a/services/registration/src/config/index.ts
+++ b/services/registration/src/config/index.ts
@@ -5,25 +5,17 @@ import fs from "fs";
 import path from "path";
 
 export let calibrationQuestionMapping: any = {};
-export let gradingGroupMapping: any = {};
 export let rubricMapping: any = {};
 
 if (config.common.production) {
   calibrationQuestionMapping = JSON.parse(
     fs.readFileSync("/tmp/calibration_question_mapping/latest", "utf8")
   );
-  gradingGroupMapping = JSON.parse(fs.readFileSync("/tmp/grading_group_mapping/latest", "utf8"));
   rubricMapping = JSON.parse(fs.readFileSync("/tmp/rubric_mapping/latest", "utf8"));
 } else {
   try {
     calibrationQuestionMapping = JSON.parse(
       fs.readFileSync(path.resolve(__dirname, "./calibration_question_mapping.json"), "utf8")
-    );
-  } catch {}
-
-  try {
-    gradingGroupMapping = JSON.parse(
-      fs.readFileSync(path.resolve(__dirname, "./grading_group_mapping.json"), "utf8")
     );
   } catch {}
 

--- a/services/registration/src/models/branch.ts
+++ b/services/registration/src/models/branch.ts
@@ -18,6 +18,11 @@ export enum ApplicationGroupType {
   STAFF = "STAFF",
 }
 
+export enum GradingGroupType {
+  GENERAL_GROUP = "generalGroup",
+  EMERGING_GROUP = "emergingGroup",
+}
+
 export interface Branch extends mongoose.Document {
   name: string;
   hexathon: Types.ObjectId;
@@ -38,6 +43,10 @@ export interface Branch extends mongoose.Document {
     enabled?: boolean;
     confirmationBranch?: Types.ObjectId;
     emails?: string[];
+  };
+  grading?: {
+    enabled?: boolean;
+    group?: GradingGroupType;
   };
 }
 
@@ -94,6 +103,17 @@ const branchSchema = new Schema<Branch>({
     type: Boolean,
     default: false,
     required: true,
+  },
+  grading: {
+    enabled: {
+      type: Boolean,
+      default: false,
+      required: true,
+    },
+    group: {
+      type: String,
+      enum: GradingGroupType,
+    },
   },
 });
 

--- a/services/registration/src/models/grader.ts
+++ b/services/registration/src/models/grader.ts
@@ -1,15 +1,15 @@
 import { AccessibleRecordModel, accessibleRecordsPlugin } from "@casl/mongoose";
 import mongoose, { Schema, model, Types } from "mongoose";
 
+import { GradingGroupType } from "./branch";
+
 export interface Grader extends mongoose.Document {
   userId: string;
   hexathon: Types.ObjectId;
   graded: number;
   skipped: number;
-  currentGradingGroup?: string;
-  completedGradingGroups: string[];
   calibrationScores: {
-    group: string;
+    group: GradingGroupType;
     score: number;
   }[];
   calibrationMapping: {
@@ -41,18 +41,13 @@ const graderSchema = new Schema<Grader>({
   },
   calibrationScores: [
     {
-      group: String,
+      group: {
+        type: String,
+        enum: GradingGroupType,
+      },
       score: Number,
     },
   ],
-  currentGradingGroup: {
-    type: String,
-  },
-  completedGradingGroups: {
-    type: [String],
-    default: [],
-    required: true,
-  },
   calibrationMapping: [
     {
       criteria: String,

--- a/services/registration/src/routes/branch.ts
+++ b/services/registration/src/routes/branch.ts
@@ -1,4 +1,4 @@
-import { asyncHandler, checkAbility } from "@api/common";
+import { asyncHandler, BadRequestError, checkAbility } from "@api/common";
 import express from "express";
 import { FilterQuery } from "mongoose";
 
@@ -33,6 +33,10 @@ branchRouter.route("/:id").get(
 branchRouter.route("/").post(
   checkAbility("update", "Branch"),
   asyncHandler(async (req, res) => {
+    if (req.body?.grading?.enabled && !req.body?.grading?.group) {
+      throw new BadRequestError("Grading group is required when grading is set");
+    }
+
     const newBranch = await BranchModel.create(req.body);
 
     return res.send(newBranch);
@@ -42,6 +46,10 @@ branchRouter.route("/").post(
 branchRouter.route("/:id").patch(
   checkAbility("update", "Branch"),
   asyncHandler(async (req, res) => {
+    if (req.body?.grading?.enabled && !req.body?.grading?.group) {
+      throw new BadRequestError("Grading group is required when grading is set");
+    }
+
     const updatedBranch = await BranchModel.findByIdAndUpdate(req.params.id, req.body, {
       new: true,
     });


### PR DESCRIPTION
### Description
This moves the grading enabled/grading group to the branch model. Thus, when someone retrieves a question, we can determine on the fly which branches are enabled for grading and retrieve questions as such. This will better integrate into the frontend repo as well.
