### PR TITLE
Put back no team case

### DIFF
--- a/services/users/src/routes/team.ts
+++ b/services/users/src/routes/team.ts
@@ -152,8 +152,8 @@ teamRoutes.route("/user/:userId").get(
     }
 
     const teams = await TeamModel.find(filter);
-    if (teams.length < 0) {
-      throw new BadRequestError("Could not find a team associated with the user.");
+    if (teams.length <= 0) {
+      res.status(200).json(teams);
     }
 
     const team = teams[0];


### PR DESCRIPTION
### Description

Users are in fact allowed to have no teams. Was causing error in displaying the team formation portal.

Caused when I deleted all the demo teams.

### Issues
-
