### PR TITLE
Modify application status, branches, and extended deadlines

### DIFF
--- a/services/registration/src/routes/application.ts
+++ b/services/registration/src/routes/application.ts
@@ -469,7 +469,7 @@ applicationRouter.route("/:id/actions/update-status").post(
 );
 
 applicationRouter.route("/:id/actions/update-application").post(
-  // checkAbility("update", "Application"),
+  checkAbility("update", "Application"),
   asyncHandler(async (req, res) => {
     const existingApplication = await ApplicationModel.findById(req.params.id).accessibleBy(
       req.ability

--- a/services/registration/src/routes/application.ts
+++ b/services/registration/src/routes/application.ts
@@ -511,7 +511,7 @@ applicationRouter.route("/:id/actions/update-application").post(
       } else if (
         existingApplication.status === StatusType.APPLIED &&
         newStatus === StatusType.CONFIRMED &&
-        confirmationBranch === null
+        confirmationBranch === "None"
       ) {
         // Applicant moved to confirmed without a confirmation branch
         throw new BadRequestError("Applicant must have a confirmation branch to be confirmed.");


### PR DESCRIPTION
### Description
Added an endpoint to edit application settings such as the application/confirmation branches, application status, and application/confirmation extended deadlines if necessary. Linked with PR in registration2 repo (https://github.com/HackGT/registration2/pull/88).
