### PR TITLE
Update the docs site with new users endpoints - minor fixes

### DIFF
--- a/docs/src/swagger-output.json
+++ b/docs/src/swagger-output.json
@@ -3037,6 +3037,66 @@
       }
     },
     "/companies": {
+      "get": {
+        "tags": ["users"],
+        "summary": "Search for a company.",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "type": "string",
+            "description": "Search term"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "string",
+            "description": "Specifies the number of valid objects to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "type": "string",
+            "description": "Specifies offset in pagination"
+          },
+          {
+            "name": "regex",
+            "in": "query",
+            "type": "string",
+            "description": "Specifies if search term uses regex or not"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "offset": {
+                  "type": "integer"
+                },
+                "total": {
+                  "type": "integer"
+                },
+                "count": {
+                  "type": "integer"
+                },
+                "profiles": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Company"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid Status"
+          }
+        }
+      },
       "post": {
         "tags": ["users"],
         "summary": "Create a new company.",
@@ -3151,12 +3211,135 @@
             "description": "Company not found"
           }
         }
+      },
+      "delete": {
+        "tags": ["users"],
+        "summary": "Deletes a company by ID.",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "integer",
+            "description": "Company ID",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted"
+          },
+          "400": {
+            "description": "Invalid Status"
+          }
+        }
+      }
+    },
+    "/companies/employees/{employeeId}": {
+      "get": {
+        "tags": ["users"],
+        "summary": "Finds and displays employee by id.",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "employeeId",
+            "in": "path",
+            "type": "integer",
+            "description": "Employee ID",
+            "required": true
+          },
+          {
+            "name": "hexathon",
+            "in": "query",
+            "type": "string",
+            "description": "Hexathon",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Company"
+              }
+            }
+          },
+          "400": {
+            "description": "Company not found"
+          }
+        }
+      }
+    },
+    "/companies/{id}/employees/accept-request": {
+      "post": {
+        "tags": ["users"],
+        "summary": "Accepts employee join requests.",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "integer",
+            "description": "ID",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Company"
+              }
+            }
+          },
+          "400": {
+            "description": "Company not found"
+          }
+        }
       }
     },
     "/companies/{id}/employees/add": {
       "post": {
         "tags": ["users"],
         "summary": "Adds an employee to the company.",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "integer",
+            "description": "ID",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Company"
+              }
+            }
+          },
+          "400": {
+            "description": "Company not found"
+          }
+        }
+      }
+    },
+    "/companies/{id}/employees/request": {
+      "post": {
+        "tags": ["users"],
+        "summary": "Sends a request to join the company.",
         "description": "",
         "produces": ["application/json"],
         "parameters": [
@@ -3211,6 +3394,381 @@
           },
           "400": {
             "description": "Company not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["users"],
+        "summary": "Deletes an employee by ID.",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "integer",
+            "description": "Employee ID",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted"
+          },
+          "400": {
+            "description": "Invalid Status"
+          }
+        }
+      }
+    },
+    "/teams": {
+      "get": {
+        "tags": ["users"],
+        "summary": "Search for a team.",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "hexathon",
+            "in": "query",
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "offset": {
+                  "type": "integer"
+                },
+                "total": {
+                  "type": "integer"
+                },
+                "count": {
+                  "type": "integer"
+                },
+                "profiles": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Team"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid Status"
+          }
+        }
+      },
+      "post": {
+        "tags": ["users"],
+        "summary": "Create a team.",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Request body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "hexathon": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "publicTeam": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Team"
+            }
+          },
+          "400": {
+            "description": "Invalid Status"
+          }
+        }
+      }
+    },
+    "/teams/{id}": {
+      "get": {
+        "tags": ["users"],
+        "summary": "Finds and displays team by team ID.",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "integer",
+            "description": "Team ID",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Team"
+                },
+                {
+                  "$ref": "#/definitions/Permission"
+                }
+              ]
+            }
+          },
+          "400": {
+            "description": "Invalid Status"
+          }
+        }
+      }
+    },
+    "/teams/add": {
+      "post": {
+        "tags": ["users"],
+        "summary": "",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Request body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "hexathon": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Team"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid Status"
+          }
+        }
+      }
+    },
+    "/teams/{id}/accept-user": {
+      "post": {
+        "tags": ["users"],
+        "summary": "Accepts a new user to an existing team.",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "integer",
+            "description": "Team ID",
+            "required": true
+          },
+          {
+            "name": "userId",
+            "in": "body",
+            "description": "User ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Profile"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid Status"
+          }
+        }
+      }
+    },
+    "/teams/user/{userId}": {
+      "get": {
+        "tags": ["users"],
+        "summary": "Gets the profile of a team member.",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "hexathon",
+            "in": "query",
+            "type": "integer",
+            "description": "User ID",
+            "required": true
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "type": "integer",
+            "description": "User ID",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Profile"
+                },
+                {
+                  "$ref": "#/definitions/Permission"
+                }
+              ]
+            }
+          },
+          "400": {
+            "description": "Invalid Status"
+          }
+        }
+      }
+    },
+    "/teams/join": {
+      "post": {
+        "tags": ["users"],
+        "summary": "Submits a request to join a team.",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Request body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "hexathon": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Join Request has been sent!",
+            "type": "string"
+          },
+          "400": {
+            "description": "Invalid Status"
+          }
+        }
+      }
+    },
+    "/teams/leave": {
+      "post": {
+        "tags": ["users"],
+        "summary": "Submits a request to leave a team.",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Request body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "hexathon": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "Invalid Status"
+          }
+        }
+      }
+    },
+    "/teams/{id}/put": {
+      "put": {
+        "tags": ["users"],
+        "summary": "",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "params",
+            "in": "params",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "description": "Team ID"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Team"
+            }
+          },
+          "400": {
+            "description": "Invalid Status"
           }
         }
       }
@@ -4033,6 +4591,49 @@
       },
       "xml": {
         "name": "Company"
+      }
+    },
+    "Team": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "hexathon": {
+          "type": "string"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "description": {
+          "type": "string"
+        },
+        "public": {
+          "type": "boolean"
+        },
+        "memberRequests": {
+          "type": "object",
+          "properties": {
+            "userId": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "default": []
+        }
+      },
+      "xml": {
+        "name": "Team"
       }
     },
     "Profile": {

--- a/docs/src/swagger-output.json
+++ b/docs/src/swagger-output.json
@@ -3239,7 +3239,7 @@
     "/companies/employees/{employeeId}": {
       "get": {
         "tags": ["users"],
-        "summary": "Finds and displays employee by id.",
+        "summary": "Finds and displays company by id.",
         "description": "",
         "produces": ["application/json"],
         "parameters": [
@@ -3530,9 +3530,6 @@
               "allOf": [
                 {
                   "$ref": "#/definitions/Team"
-                },
-                {
-                  "$ref": "#/definitions/Permission"
                 }
               ]
             }


### PR DESCRIPTION
Made the following minor fixes to the new users endpoints in docs/src/swagger-output.json:

1. Changed "summary" from "Finds and displays employee by id." to "Finds and displays company by id." (line 3242).
2. Removed the reference to "Permission" (lines 3534 to 3536).