### PR TITLE
Move dev database connections to an environment variable

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -1,3 +1,11 @@
 PRODUCTION=false
 
 GOOGLE_APPLICATION_CREDENTIALS=
+
+MONGO_URI="mongodb://localhost"
+REDIS_URI="redis://localhost"
+POSTGRES_URI="postgres://postgres@localhost"
+
+# The following variables are needed for services with Prisma ORM
+POSTGRES_URI_EXPO_SERVICE=${POSTGRES_URI}/expo
+POSTGRES_URI_FINANCE_SERVICE=${POSTGRES_URI}/finance

--- a/config/src/dev.ts
+++ b/config/src/dev.ts
@@ -10,13 +10,13 @@ export const DOCS: DocsConfig = {
 
 export const DATABASE: DatabaseConfig = {
   mongo: {
-    uri: "mongodb://localhost",
+    uri: String(process.env.MONGO_URI),
   },
   redis: {
-    uri: "redis://localhost",
+    uri: String(process.env.REDIS_URI),
   },
   postgres: {
-    uri: "postgres://postgres@localhost",
+    uri: String(process.env.POSTGRES_URI),
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@hex-labs/eslint-config": "^1.3.1",
     "@hex-labs/prettier-config": "^1.3.1",
     "concurrently": "^7.0.0",
+    "dotenv-cli": "^7.2.1",
     "eslint": "^8.9.0",
     "eslint-import-resolver-typescript": "^2.5.0",
     "husky": ">=6",

--- a/services/expo/package.json
+++ b/services/expo/package.json
@@ -8,13 +8,13 @@
     "prebuild": "yarn prisma-generate",
     "build": "tsc --build --force",
     "clean": "tsc --build --clean",
-    "start:normal": "node -r tsconfig-paths/register dist/app.js",
     "dev": "nodemon --watch 'src/**/*' --exec \"ts-node\" -r tsconfig-paths/register src/app.ts",
-    "migrate:dev": "prisma migrate dev",
+    "migrate:dev": "dotenv -e ../../config/.env prisma migrate dev",
     "migrate:deploy": "prisma migrate deploy",
     "prisma-generate": "prisma format && prisma generate",
     "seed": "prisma db seed --preview-feature",
-    "start": "yarn migrate:deploy && yarn start:normal"
+    "start": "yarn migrate:deploy && yarn start:normal",
+    "start:normal": "node -r tsconfig-paths/register dist/app.js"
   },
   "author": "",
   "license": "ISC",

--- a/services/expo/prisma/schema.prisma
+++ b/services/expo/prisma/schema.prisma
@@ -5,7 +5,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("POSTGRES_URL")
+  url      = env("POSTGRES_URI_EXPO_SERVICE")
 }
 
 enum AssignmentStatus {

--- a/services/finance/package.json
+++ b/services/finance/package.json
@@ -8,13 +8,13 @@
     "prebuild": "yarn prisma-generate",
     "build": "tsc --build --force",
     "clean": "tsc --build --clean",
-    "start:normal": "node -r tsconfig-paths/register dist/app.js",
     "dev": "yarn prisma-generate && nodemon --watch 'src/**/*' --exec \"ts-node\" -r tsconfig-paths/register src/app.ts",
-    "migrate:dev": "prisma migrate dev",
+    "migrate:dev": "dotenv -e ../../config/.env prisma migrate dev",
     "migrate:deploy": "prisma migrate deploy",
     "prisma-generate": "prisma format && prisma generate && graphql-codegen",
     "seed": "prisma db seed --preview-feature",
-    "start": "yarn migrate:deploy && yarn start:normal"
+    "start": "yarn migrate:deploy && yarn start:normal",
+    "start:normal": "node -r tsconfig-paths/register dist/app.js"
   },
   "author": "",
   "license": "ISC",

--- a/services/finance/prisma/schema.prisma
+++ b/services/finance/prisma/schema.prisma
@@ -5,7 +5,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("POSTGRES_URL")
+  url      = env("POSTGRES_URI_FINANCE_SERVICE")
 }
 
 enum RequisitionStatus {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4895,6 +4895,21 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv-cli@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/dotenv-cli/-/dotenv-cli-7.2.1.tgz#e595afd9ebfb721df9da809a435b9aa966c92062"
+  integrity sha512-ODHbGTskqRtXAzZapDPvgNuDVQApu4oKX8lZW7Y0+9hKA6le1ZJlyRS687oU9FXjOVEDU/VFV6zI125HzhM1UQ==
+  dependencies:
+    cross-spawn "^7.0.3"
+    dotenv "^16.0.0"
+    dotenv-expand "^10.0.0"
+    minimist "^1.2.6"
+
+dotenv-expand@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-10.0.0.tgz#12605d00fb0af6d0a592e6558585784032e4ef37"
+  integrity sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==
+
 dotenv@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.0.tgz#c619001253be89ebb638d027b609c75c26e47411"


### PR DESCRIPTION
### Description

I moved the development database connections variable to a `.env` file so it allows developers to change these variables independently easier outside of source control. Additionally, this way it allows us to read the `.env` variables in the prisma schema files and only requires one `.env` file globally for the backend system.
