### PR TITLE
Create project hex filter

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -1,7 +1,7 @@
 PRODUCTION=false
 
 GOOGLE_CLOUD_PROJECT="hexlabs-cloud"
-GOOGLE_APPLICATION_CREDENTIALS=/home/Nicolas/Documents/Projects/Hexlabs/api/config/google-cloud-credentials.json
+GOOGLE_APPLICATION_CREDENTIALS=
 
 MONGO_URI="mongodb://localhost"
 REDIS_URI="redis://localhost"

--- a/config/.env.example
+++ b/config/.env.example
@@ -1,7 +1,7 @@
 PRODUCTION=false
 
 GOOGLE_CLOUD_PROJECT="hexlabs-cloud"
-GOOGLE_APPLICATION_CREDENTIALS=
+GOOGLE_APPLICATION_CREDENTIALS=/home/Nicolas/Documents/Projects/Hexlabs/api/config/google-cloud-credentials.json
 
 MONGO_URI="mongodb://localhost"
 REDIS_URI="redis://localhost"

--- a/docs/src/swagger-output.json
+++ b/docs/src/swagger-output.json
@@ -33,6 +33,10 @@
     {
       "name": "hardware",
       "description": "Everything about hardware."
+    },
+    {
+      "name": "expo",
+      "description": "Everything about expo."
     }
   ],
   "schemes": ["https", "http"],
@@ -4304,6 +4308,40 @@
           }
         }
       }
+    },
+    "/project/special/dashboard": {
+      "post": {
+        "tags": ["expo"],
+        "summary": "Gets all submitted projects for hexathon(s)",
+        "description": "",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "hexathon",
+            "in": "query",
+            "type": "string",
+            "description": "Hexathon id used to filter expo projects"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Project"
+                  }
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "Hexathon not found or you do not have permission."
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -5358,6 +5396,86 @@
         "item": {
           "type": "number",
           "required": true
+        }
+      }
+    },
+    "Project": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "devpostUrl": {
+          "type": "string"
+        },
+        "githubUrl": {
+          "type": "string"
+        },
+        "roomUrl": {
+          "type": "string"
+        },
+        "expo": {
+          "type": "number"
+        },
+        "round": {
+          "type": "number"
+        },
+        "table": {
+          "type": "number"
+        },
+        "tableGroup": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        },
+        "hexathon": {
+          "type": "object"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        },
+        "ballots": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        },
+        "assignment": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        },
+        "winners": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        },
+        "tableGroupId": {
+          "type": "number"
         }
       }
     }

--- a/services/expo/src/routes/project.ts
+++ b/services/expo/src/routes/project.ts
@@ -54,7 +54,6 @@ projectRoutes.route("/").get(
 );
 
 projectRoutes.route("/special/team-validation").post(async (req, res) => {
-  console.log();
   const resp = await validateTeam(req.user, req.body.members, req);
   if (resp.error) {
     res.status(400).json(resp);
@@ -173,7 +172,6 @@ projectRoutes.route("/").post(async (req, res) => {
     }
   }
 
-  console.log(!minCapacityTableGroup);
   if (!minCapacityTableGroup) {
     res.status(400).send({
       error: true,
@@ -504,7 +502,8 @@ projectRoutes.route("/special/dashboard").get(
       req
     );
 
-    if (hexathons.length === undefined) {
+    // check for hexathon id filter
+    if (req.query?.hexathon) {
       let filtered_projects = [];
       for (const project in projects) {
         if (projects[project].hexathon === hexathons.id) {

--- a/services/expo/src/routes/project.ts
+++ b/services/expo/src/routes/project.ts
@@ -503,7 +503,7 @@ projectRoutes.route("/special/dashboard").get(
       },
       req
     );
-    console.log(hexathons);
+
     if (hexathons.length === undefined) {
       let filtered_projects = [];
       for (const project in projects) {

--- a/services/expo/src/routes/project.ts
+++ b/services/expo/src/routes/project.ts
@@ -54,6 +54,7 @@ projectRoutes.route("/").get(
 );
 
 projectRoutes.route("/special/team-validation").post(async (req, res) => {
+  console.log();
   const resp = await validateTeam(req.user, req.body.members, req);
   if (resp.error) {
     res.status(400).json(resp);
@@ -172,6 +173,7 @@ projectRoutes.route("/").post(async (req, res) => {
     }
   }
 
+  console.log(!minCapacityTableGroup);
   if (!minCapacityTableGroup) {
     res.status(400).send({
       error: true,
@@ -491,24 +493,35 @@ projectRoutes.route("/special/dashboard").get(
       },
     });
 
+    const hexUrl = req.query?.hexathon ? `/hexathons/${req.query?.hexathon}` : `/hexathons`;
     const hexathons = await apiCall(
       Service.HEXATHONS,
       {
-        url: `/hexathons`,
+        url: hexUrl,
         method: "GET",
+        params: { id: req.query?.hexathon },
       },
       req
     );
-
-    for (const project in projects) {
-      for (const hexathon in hexathons) {
-        if (projects[project].hexathon === hexathons[hexathon].id) {
-          projects[project].hexathon = hexathons[hexathon];
+    console.log(hexathons);
+    if (hexathons.length === undefined) {
+      let filtered_projects = [];
+      for (const project in projects) {
+        if (projects[project].hexathon === hexathons.id) {
+          filtered_projects.push(projects[project]);
         }
       }
+      res.status(200).json(filtered_projects);
+    } else {
+      for (const project in projects) {
+        for (const hexathon in hexathons) {
+          if (projects[project].hexathon === hexathons[hexathon].id) {
+            projects[project].hexathon = hexathons[hexathon];
+          }
+        }
+      }
+      res.status(200).json(projects);
     }
-
-    res.status(200).json(projects);
   })
 );
 


### PR DESCRIPTION
### Description
- Created filter for expo route `/projects/special/dashboard` to accept hexathon id in query and only shows projects from that hexathon
- Created docs for expo routes and added relevant route/definitions accordingly
- With hexathon id filter (it's hard to tell but only one project shows up here):
![Postman1](https://github.com/HackGT/api/assets/31454324/0281679f-a065-4a5e-8dae-1b6daf78a14e)
- Without filter (based on the line numbers multiple projects are shown):
![Postman2](https://github.com/HackGT/api/assets/31454324/d3affd0a-3844-4070-8b8f-0ab986559bcd)
