### PR TITLE
Included table groups to project get request

### DIFF
--- a/services/expo/src/routes/project.ts
+++ b/services/expo/src/routes/project.ts
@@ -89,6 +89,7 @@ projectRoutes.route("/").get(
           },
         },
         members: true,
+        tableGroup: true,
       },
       orderBy: {
         id: "asc",


### PR DESCRIPTION
### Description
- Added table groups to be included in the response for the /projects get request in expo
- Tested this locally in postman to confirm this works: 
![image](https://github.com/HackGT/api/assets/31454324/fc66f8d7-19f4-419e-bc30-e3d44823463f)


