### PR TITLE
bugfix: query for correct team owner ObjectId when adding a user by e…

### DIFF
--- a/services/hexathons/src/routes/team.ts
+++ b/services/hexathons/src/routes/team.ts
@@ -139,9 +139,18 @@ teamRoutes.route("/add").post(
       throw new BadRequestError("User has already joined another team for this event.");
     }
 
+    const acceptingUser = await HexathonUserModel.findOne({
+      hexathon: { $eq: hexathon },
+      userId: req.user?.uid,
+    });
+
+    if (!acceptingUser) {
+      throw new BadRequestError("User has not registered for this event!");
+    }
+
     const teamToJoin = await TeamModel.findOne({
       hexathon,
-      members: req.user?.uid,
+      members: acceptingUser.id,
     });
 
     if (!teamToJoin) {


### PR DESCRIPTION
…mail

### Description

A [recent commit](https://github.com/HackGT/api/commit/e5ce033bf6b972ee6d0e6e9363712e2c06addb8e) to the `POST /teams/add` route causes the team lookup to use `req.user.id`, which is not a valid ObjectId.

As a result, I am unable to add other users to my team by email. I get this error: `Cast to ObjectId failed for value "<my uid, which is not a valid ObjectId>" (type string) at path "members" for model "Team"`.

I don't have any dev environment set up -- this is just my best shot following patterns from other routes.

### Issues
Unable to add other users by email to a hexathon team.
-
