### PR TITLE
Create backend support for multiple category groups

### DIFF
--- a/services/expo/prisma/migrations/20231004044218_/migration.sql
+++ b/services/expo/prisma/migrations/20231004044218_/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `categoryGroupId` on the `user` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "user" DROP CONSTRAINT "user_categoryGroupId_fkey";
+
+-- AlterTable
+ALTER TABLE "user" DROP COLUMN "categoryGroupId";
+
+-- CreateTable
+CREATE TABLE "_CategoryGroupToUser" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_CategoryGroupToUser_AB_unique" ON "_CategoryGroupToUser"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_CategoryGroupToUser_B_index" ON "_CategoryGroupToUser"("B");
+
+-- AddForeignKey
+ALTER TABLE "_CategoryGroupToUser" ADD CONSTRAINT "_CategoryGroupToUser_A_fkey" FOREIGN KEY ("A") REFERENCES "category_group"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_CategoryGroupToUser" ADD CONSTRAINT "_CategoryGroupToUser_B_fkey" FOREIGN KEY ("B") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/services/expo/prisma/migrations/20231004044749_/migration.sql
+++ b/services/expo/prisma/migrations/20231004044749_/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `isJudging` on the `user` table. All the data in the column will be lost.
+  - You are about to drop the column `isSponsor` on the `user` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "user_isJudging_idx";
+
+-- DropIndex
+DROP INDEX "user_isSponsor_idx";
+
+-- AlterTable
+ALTER TABLE "category_group" ADD COLUMN     "isSponsor" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "user" DROP COLUMN "isJudging",
+DROP COLUMN "isSponsor";

--- a/services/expo/prisma/migrations/20231011021605_/migration.sql
+++ b/services/expo/prisma/migrations/20231011021605_/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - The values [STARTED] on the enum `AssignmentStatus` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "AssignmentStatus_new" AS ENUM ('QUEUED', 'COMPLETED', 'SKIPPED');
+ALTER TABLE "assignment" ALTER COLUMN "status" TYPE "AssignmentStatus_new" USING ("status"::text::"AssignmentStatus_new");
+ALTER TYPE "AssignmentStatus" RENAME TO "AssignmentStatus_old";
+ALTER TYPE "AssignmentStatus_new" RENAME TO "AssignmentStatus";
+DROP TYPE "AssignmentStatus_old";
+COMMIT;
+
+-- AlterTable
+ALTER TABLE "assignment" ALTER COLUMN "status" SET DEFAULT 'QUEUED';

--- a/services/expo/prisma/schema.prisma
+++ b/services/expo/prisma/schema.prisma
@@ -10,7 +10,6 @@ datasource db {
 
 enum AssignmentStatus {
   QUEUED
-  STARTED
   COMPLETED
   SKIPPED
 }
@@ -27,7 +26,7 @@ model Assignment {
   id          Int              @id @default(autoincrement())
   user        User             @relation(fields: [userId], references: [id])
   project     Project          @relation(fields: [projectId], references: [id])
-  status      AssignmentStatus
+  status      AssignmentStatus @default(QUEUED)
   priority    Int?
   categoryIds Int[]
   createdAt   DateTime         @default(now())
@@ -81,6 +80,7 @@ model CategoryGroup {
   categories Category[]
   hexathon   String
   users      User[]
+  isSponsor  Boolean    @default(false)
 
   @@index([hexathon])
   @@map("category_group")
@@ -174,17 +174,11 @@ model User {
   name          String
   email         String         @unique
   userId        String         @unique
-  isJudging     Boolean        @default(false)
-  isSponsor     Boolean        @default(false)
-  categoryGroup CategoryGroup? @relation(fields: [categoryGroupId], references: [id])
+  categoryGroups CategoryGroup[]
   ballots       Ballot[]
   projects      Project[]
   assignments   Assignment[]
 
-  categoryGroupId Int?
-
-  @@index([isJudging])
-  @@index([isSponsor])
   @@map("user")
 }
 


### PR DESCRIPTION
### Description
- Backend support for multiple category groups
- Clean up auto assign
- Associated schema changes and get rid of `STARTED` assignment as not needed
- Add checking to ensure only 1 category group per person per hexathon
- Associated frontend PR (https://github.com/HackGT/timber/pull/204)

**Please don't merge in this PR after approval. Will need to do manual database updates first otherwise migration won't work.**
