### PR TITLE
Reese/hexathon files

### DIFF
--- a/services/files/src/common/storage.ts
+++ b/services/files/src/common/storage.ts
@@ -14,8 +14,8 @@ export const uploadFile = async (
 ) => {
   const { originalname, buffer } = file;
   let folderName = "";
-  if (folder !== "") {
-    folderName = `${folder  }/`;
+  if (folder !== undefined) {
+    folderName = `${folder}/`;
   }
   const googleFileName = `${folderName}${path.parse(originalname).name}_${Date.now()}`;
   const blob = storage.bucket(bucketName).file(googleFileName);

--- a/services/files/src/common/storage.ts
+++ b/services/files/src/common/storage.ts
@@ -7,9 +7,18 @@ import { File } from "../models/file";
 
 const storage = new Storage();
 
-export const uploadFile = async (file: Express.Multer.File, bucketName: string) => {
+export const uploadFile = async (
+  file: Express.Multer.File,
+  bucketName: string,
+  folder?: string
+) => {
   const { originalname, buffer } = file;
-  const googleFileName = `${path.parse(originalname).name}_${Date.now()}`;
+  if (folder) {
+    folder += "/";
+  } else {
+    folder = "";
+  }
+  const googleFileName = `${folder}${path.parse(originalname).name}_${Date.now()}`;
   const blob = storage.bucket(bucketName).file(googleFileName);
 
   const blobStream = blob.createWriteStream({

--- a/services/files/src/common/storage.ts
+++ b/services/files/src/common/storage.ts
@@ -13,12 +13,11 @@ export const uploadFile = async (
   folder?: string
 ) => {
   const { originalname, buffer } = file;
-  if (folder) {
-    folder += "/";
-  } else {
-    folder = "";
+  let folderName = "";
+  if (folder !== "") {
+    folderName = `${folder  }/`;
   }
-  const googleFileName = `${folder}${path.parse(originalname).name}_${Date.now()}`;
+  const googleFileName = `${folderName}${path.parse(originalname).name}_${Date.now()}`;
   const blob = storage.bucket(bucketName).file(googleFileName);
 
   const blobStream = blob.createWriteStream({

--- a/services/files/src/routes/file.ts
+++ b/services/files/src/routes/file.ts
@@ -34,7 +34,7 @@ const multerMid = multer({
 
 export const fileRoutes = express.Router();
 
-fileRoutes.route("/upload/:folder").post(
+fileRoutes.route("/upload/:folder?").post(
   checkAbility("create", "File"),
   multerMid.single("file"),
   asyncHandler(async (req, res) => {

--- a/services/files/src/routes/file.ts
+++ b/services/files/src/routes/file.ts
@@ -34,7 +34,7 @@ const multerMid = multer({
 
 export const fileRoutes = express.Router();
 
-fileRoutes.route("/upload").post(
+fileRoutes.route("/upload/:folder").post(
   checkAbility("create", "File"),
   multerMid.single("file"),
   asyncHandler(async (req, res) => {
@@ -44,7 +44,8 @@ fileRoutes.route("/upload").post(
 
     const googleFileName = await uploadFile(
       req.file,
-      config.common.googleCloud.storageBuckets.default
+      config.common.googleCloud.storageBuckets.default,
+      req.params.folder
     );
 
     const file = await FileModel.create({


### PR DESCRIPTION
### Description
I changed the files/upload route to take in an optional folder parameter that specifies the folder path.

You can test it in Postman:
with folder: http://localhost:8005/files/upload/{folder}
without folder (normal): https://localhost:8005/files/upload

Headers: Key: Content-Type, Value: multipart/form-data
Body: select "form-data", create a key called "file" of File type, and upload a file in value

### Future Issues
To be able to do the other part of the issue (organizing resumes by hexathon), I have to call this route with the updated parameter. To my knowledge this change is only necessary in registration2. I can create an issue and do that if this is approved.

