### PR TITLE
Independent Table Number and Table Group Assignment

### DIFF
--- a/services/expo/src/routes/project.ts
+++ b/services/expo/src/routes/project.ts
@@ -214,12 +214,12 @@ projectRoutes.route("/").post(
       }
 
       // check for first free table group to assign table number to
-      let isFreeTableGroup = projectsInCurrentExpoAndTableGroup.length < tableGroup.tableCapacity; 
+      const isFreeTableGroup = projectsInCurrentExpoAndTableGroup.length < tableGroup.tableCapacity; 
       if (isFreeTableGroup && firstFreeTableGroup === undefined) {
         firstFreeTableGroup = tableGroup;
       }
 
-      totalCapacity += tableGroup.capacity;
+      totalCapacity += tableGroup.tableCapacity;
     }
 
     // no free table could be found; all table groups' capacities are full

--- a/services/expo/src/routes/project.ts
+++ b/services/expo/src/routes/project.ts
@@ -199,39 +199,39 @@ projectRoutes.route("/").post(
       },
     });
 
-    let minCapacityTableGroup: undefined | TableGroup;
-    let minCapacityValue = 1;
+    let firstFreeTableGroup: undefined | TableGroup;
+    let totalCapacity = 0;
+    const tableNumberSet = new Set();
 
+    // select first non-empty tableGroup
     for (const tableGroup of tableGroups) {
       const projectsInCurrentExpoAndTableGroup = projectsInCurrentExpo.filter(
         project => project.tableGroupId === tableGroup.id
       );
-      if (
-        projectsInCurrentExpoAndTableGroup.length < tableGroup.tableCapacity &&
-        projectsInCurrentExpoAndTableGroup.length / tableGroup.tableCapacity < minCapacityValue
-      ) {
-        minCapacityTableGroup = tableGroup;
-        minCapacityValue = projectsInCurrentExpoAndTableGroup.length / tableGroup.tableCapacity;
+
+      for (const project of projectsInCurrentExpoAndTableGroup) {
+        tableNumberSet.add(project.table);
       }
+
+      // check for first free table group to assign table number to
+      let isFreeTableGroup = projectsInCurrentExpoAndTableGroup.length < tableGroup.tableCapacity; 
+      if (isFreeTableGroup && firstFreeTableGroup === undefined) {
+        firstFreeTableGroup = tableGroup;
+      }
+
+      totalCapacity += tableGroup.capacity;
     }
 
-    if (!minCapacityTableGroup) {
+    // no free table could be found; all table groups' capacities are full
+    if (!firstFreeTableGroup) {
       throw new BadRequestError(
         "Submission could not be saved due to issue with table groups - please contact help desk"
       );
     }
 
-    const projectsInCurrentExpoAndTableGroup = projectsInCurrentExpo.filter(
-      project => project.tableGroupId === minCapacityTableGroup?.id
-    );
-
+    // assigns table to first unused number 
     let tableNumber;
-    const tableNumberSet = new Set();
-    for (const project of projectsInCurrentExpoAndTableGroup) {
-      tableNumberSet.add(project.table);
-    }
-
-    for (let i = 1; i <= minCapacityTableGroup.tableCapacity; i++) {
+    for (let i = 1; i <= totalCapacity; i++) {
       if (!tableNumberSet.has(i)) {
         tableNumber = i;
         break;
@@ -273,7 +273,7 @@ projectRoutes.route("/").post(
             connect: data.prizes.map((prizeId: any) => ({ id: prizeId })),
           },
           tableGroup: {
-            connect: { id: minCapacityTableGroup.id },
+            connect: { id: firstFreeTableGroup.id },
           },
         },
       });


### PR DESCRIPTION
### Description
- Linked to expo [issue](https://github.com/HackGT/timber/issues/207)
- Changed table number assignment **on project submission** so that each table number is no longer assigned to every table group once (based on whichever table group has the lowest project ratio to capacity). Instead, a global capacity is tracked across all table groups so that every table number assigned to a new project is guaranteed to be unique, even among other table groups.
- This does not change how existing table numbers were assigned in previous hexathons, just how assignment works for future project submissions.

### Issues

