### PR TITLE
Sort by points.numCollected in /:hexathonId/users

### DIFF
--- a/services/hexathons/src/routes/hexathon-users.ts
+++ b/services/hexathons/src/routes/hexathon-users.ts
@@ -57,6 +57,7 @@ hexathonUserRouter.route("/:hexathonId/users").get(
     const offset = parseInt(req.query.offset as string) || 0;
     const hexathonUsers = await HexathonUserModel.accessibleBy(req.ability)
       .find(filter)
+      .sort({ "points.numCollected": 'desc', name: 'asc' })
       .skip(offset)
       .limit(limit);
 


### PR DESCRIPTION
Sorts the db fetch by num points (descending) in the /:hexathonId/users route

todo: we can maybe make this contingent on a request param. This change is primarily for the points leaderboard on livesite.